### PR TITLE
Adding Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,37 @@
+---
+name: Report Bug
+about: For reporting on bugs in the repository.
+title: 'Bug - '
+labels: bug
+assignees: ''
+
+---
+
+### Summary
+
+<!-- Summarize the bug encountered concisely -->
+
+### Steps to reproduce
+
+<!-- How one can reproduce the issue - this is very important -->
+
+### Example
+
+<!-- If possible, please create an example that exhibits the problematic behaviour, and link to it here in the bug report -->
+
+### What is the current *bug* behavior?
+
+<!-- What actually happens -->
+
+### What is the expected *correct* behavior?
+
+<!-- What you should see instead -->
+
+### Relevant logs and/or screenshots
+
+<!-- Paste any relevant logs - please use code blocks (```) to format console output,
+logs, and code as it's very hard to read otherwise. -->
+
+### Possible fixes
+
+<!-- If you can, link to the line of code that might be responsible for the problem -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,34 @@
+---
+name: Feature Request
+about: For requesting new features or enhancements.
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+### Problem to solve
+
+<!-- What problem do we solve? -->
+
+### Intended users
+
+<!-- Who will use this feature? If known, include any of the following: types of users (e.g. Developer), personas, or specific company roles (e.g. Release Manager). It's okay to write "Unknown" and fill this field in later. -->
+
+### Further details
+
+<!-- Include use cases, benefits, and/or goals (contributes to our vision?) -->
+
+### Proposal
+
+<!-- How are we going to solve the problem? -->
+
+### Permissions and Security
+
+<!-- What permissions are required to perform the described actions? Are they consistent with the existing permissions? Is the proposed behavior consistent between the UI, API, and other access methods? -->
+
+### What does success look like, and how can we measure that?
+
+<!-- Define both the success metrics and acceptance criteria. Note that success metrics indicate the desired business outcomes, while acceptance criteria indicate when the solution is working correctly. If there is no way to measure success, link to an issue that will implement a way to measure this. -->
+
+### Links / references

--- a/.github/PULL_REQUEST_TEMPLATE/general.md
+++ b/.github/PULL_REQUEST_TEMPLATE/general.md
@@ -1,0 +1,32 @@
+---
+name: General
+about: This a gerneral pull request template to be used for any reason
+title: ''
+labels: ''
+assignees: ''
+---
+
+### What does this MR do?
+
+<!--
+Describe in detail what your merge request does, why it does that, etc. Merge
+requests without an adequate description will not be reviewed until one is
+added.
+
+Please also keep this description up-to-date with any discussion that takes
+place so that reviewers can understand your intent. This is especially
+important if they didn't participate in the discussion.
+
+Make sure to remove this comment when you are done.
+-->
+
+### General checklist
+
+- [ ] [Documentation](README.md) created/updated
+- [ ] Changelog entry added, if necessary
+- [ ] Tests added for this feature/bug
+- [ ] Conforms to the [style guides](https://www.canada.ca/en/government/about/design-system.html)
+
+### Related issues
+
+<!-- list issues that are being closed or worked on with this MR -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,49 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the department
+* Showing empathy towards other members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project, members or ESDC.
+Examples of representing a project, members or ESDC include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at _project email_.
+All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html


### PR DESCRIPTION
Adding Templates for:

- Bug issue template
- Feature issue template
- General PR template (with checklist)
- Code of Conduct (adopted from [Contributor Covenant](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html))