### PR TITLE
Align template license to MIT template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Her Majesty the Queen in Right of Canada, as represented by the Treasury Board of Canada Secretariat, 2018
+Copyright (c) 2019 Government of Canada
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The format for MIT is supposed to be "Copyright (c) [year] [fullname]"
Updated to current year and revereted to Government of Canada as per WET https://github.com/wet-boew/wet-boew/blob/master/License-en.txt