### PR TITLE
Add commit message templates

### DIFF
--- a/.github/COMMIT_MESSAGE_TEMPLATE/chore.md
+++ b/.github/COMMIT_MESSAGE_TEMPLATE/chore.md
@@ -1,0 +1,13 @@
+chore(scope): Summarize the change (updating grunt tasks etc; no production code change) in less than 50 characters 
+
+Because:
+- Explain the reasons you made this change
+- Make a new bullet for each reason
+- Each line should be under 72 characters
+
+Explain exactly what was done in this commit with more depth than the
+50 character subject line. Remember to wrap at 72 characters!
+
+Include any additional notes, relevant links, or co-authors.
+
+(scope) is optional

--- a/.github/COMMIT_MESSAGE_TEMPLATE/docs.md
+++ b/.github/COMMIT_MESSAGE_TEMPLATE/docs.md
@@ -1,0 +1,13 @@
+docs(scope): Summarize the change to the documentation in less than 50 characters 
+
+Because:
+- Explain the reasons you made this change
+- Make a new bullet for each reason
+- Each line should be under 72 characters
+
+Explain exactly what was done in this commit with more depth than the
+50 character subject line. Remember to wrap at 72 characters!
+
+Include any additional notes, relevant links, or co-authors.
+
+(scope) is optional

--- a/.github/COMMIT_MESSAGE_TEMPLATE/feat.md
+++ b/.github/COMMIT_MESSAGE_TEMPLATE/feat.md
@@ -1,0 +1,13 @@
+feat(scope): Summarize the change (new feature for the user, not a new feature for build script) in less than 50 characters 
+
+Because:
+- Explain the reasons you made this change
+- Make a new bullet for each reason
+- Each line should be under 72 characters
+
+Explain exactly what was done in this commit with more depth than the
+50 character subject line. Remember to wrap at 72 characters!
+
+Include any additional notes, relevant links, or co-authors.
+
+(scope) is optional

--- a/.github/COMMIT_MESSAGE_TEMPLATE/fix.md
+++ b/.github/COMMIT_MESSAGE_TEMPLATE/fix.md
@@ -1,0 +1,13 @@
+fix(scope): Summarize the change (bug fix for the user, not a fix to a build script) in less than 50 characters 
+
+Because:
+- Explain the reasons you made this change
+- Make a new bullet for each reason
+- Each line should be under 72 characters
+
+Explain exactly what was done in this commit with more depth than the
+50 character subject line. Remember to wrap at 72 characters!
+
+Include any additional notes, relevant links, or co-authors.
+
+(scope) is optional

--- a/.github/COMMIT_MESSAGE_TEMPLATE/refactor.md
+++ b/.github/COMMIT_MESSAGE_TEMPLATE/refactor.md
@@ -1,0 +1,13 @@
+refactor(scope): Summarize the change (refactoring production code, eg. renaming a variable) in less than 50 characters 
+
+Because:
+- Explain the reasons you made this change
+- Make a new bullet for each reason
+- Each line should be under 72 characters
+
+Explain exactly what was done in this commit with more depth than the
+50 character subject line. Remember to wrap at 72 characters!
+
+Include any additional notes, relevant links, or co-authors.
+
+(scope) is optional

--- a/.github/COMMIT_MESSAGE_TEMPLATE/style.md
+++ b/.github/COMMIT_MESSAGE_TEMPLATE/style.md
@@ -1,0 +1,13 @@
+style(scope): Summarize the change (formatting, missing semi colons, typo, etc; no production code change) in less than 50 characters 
+
+Because:
+- Explain the reasons you made this change
+- Make a new bullet for each reason
+- Each line should be under 72 characters
+
+Explain exactly what was done in this commit with more depth than the
+50 character subject line. Remember to wrap at 72 characters!
+
+Include any additional notes, relevant links, or co-authors.
+
+(scope) is optional

--- a/.github/COMMIT_MESSAGE_TEMPLATE/test.md
+++ b/.github/COMMIT_MESSAGE_TEMPLATE/test.md
@@ -1,0 +1,13 @@
+test(scope): Summarize the change (adding missing tests, refactoring tests; no production code change) in less than 50 characters 
+
+Because:
+- Explain the reasons you made this change
+- Make a new bullet for each reason
+- Each line should be under 72 characters
+
+Explain exactly what was done in this commit with more depth than the
+50 character subject line. Remember to wrap at 72 characters!
+
+Include any additional notes, relevant links, or co-authors.
+
+(scope) is optional


### PR DESCRIPTION
---
name: General
about: This a gerneral pull request template to be used for any reason
title: 'Add commit message templates'
labels: ''
assignees: 'nschonni'
---

### What does this MR do?
Because commit message templates were missing this commit adds 7 templates with semantic messaging.

### General checklist

- [n.a.] [Documentation](README.md) created/updated
- [n.a.] Changelog entry added, if necessary
- [n.a.] Tests added for this feature/bug
- [n.a.] Conforms to the [style guides](https://www.canada.ca/en/government/about/design-system.html)

### Related issues
None